### PR TITLE
Fixes Player and Bosses Spawn issues with dead ends

### DIFF
--- a/First Try Roguelike/Assets/Scripts/Game Management/Dungeon.cs
+++ b/First Try Roguelike/Assets/Scripts/Game Management/Dungeon.cs
@@ -20,7 +20,7 @@ public class Dungeon : MonoBehaviour
         new Vector3Int(-PLAYER_BOSS_DISTANCE,0), 
         new Vector3Int(-PLAYER_BOSS_DISTANCE, PLAYER_BOSS_DISTANCE) };
 
-    //This method is supposed to put the player on a valid FLOOR tile.
+    //This method is supposed to put the player and any item or enemy on a valid FLOOR tile.
     //It seems to work fine but maybe it needs some tunning
     public Vector2Int GetRandomFloorPosition(){
         Vector2Int candidatePosition = Vector2Int.zero;

--- a/First Try Roguelike/Assets/Scripts/Game Management/EnemySpawner.cs
+++ b/First Try Roguelike/Assets/Scripts/Game Management/EnemySpawner.cs
@@ -35,13 +35,13 @@ public class EnemySpawner : Spawner
     internal void SpawnFinalBoss(int difficultyLevel, Dungeon dungeon)
     {
         finalBossPrefab.gameObject.tag = ENEMY_TAG;
-        spawnPrefabsOnDungeonByAmount(dungeon, finalBossPrefab, FINAL_BOSS_AMOUNT);
+        spawnFinalBossOnDungeonByAmount(dungeon, finalBossPrefab, FINAL_BOSS_AMOUNT);
     }
 
     internal void SpawnMidLevelBoss(int difficultyLevel, Dungeon dungeon)
     {
         midLevelBossPrefab.gameObject.tag = ENEMY_TAG;
-        spawnPrefabsOnDungeonByAmount(dungeon, midLevelBossPrefab, MIDLEVEL_BOSS_AMOUNT);
+        spawnMidLevelBossOnDungeonByAmount(dungeon, midLevelBossPrefab, MIDLEVEL_BOSS_AMOUNT);
     }
 
 }

--- a/First Try Roguelike/Assets/Scripts/Game Management/GameManager.cs
+++ b/First Try Roguelike/Assets/Scripts/Game Management/GameManager.cs
@@ -194,7 +194,11 @@ public class GameManager : MonoBehaviour
         // Generate New Dungeon In Place 'SPACE'
         if(Input.GetKeyDown(KeyCode.Space)){
             if (SettingsManager.GetRegenerateDungeonOn()) {
-                CreateNewDungeon();
+
+                // Decide which level needs to be created based on story
+                if (IsFinalLevel()) CreateFinalBossDungeon();
+                    else if (IsMidLevelBossLevel()) CreateMidLevelBossDungeon();
+                        else CreateNewDungeon();
             }
         }
     }

--- a/First Try Roguelike/Assets/Scripts/Game Management/GameManager.cs
+++ b/First Try Roguelike/Assets/Scripts/Game Management/GameManager.cs
@@ -112,10 +112,17 @@ public class GameManager : MonoBehaviour
         destroyAllSpawns();
         // Places the tiles on the tilemap to create the dungeon layout
         GenerateDungeonByName(RANDOM_WALK_ALGORITHM);
-        // Sets the position of the main player inside the dungeon
-        PlacePlayerOnDungeon();
         // Instantiates the items that will be available on the dungeon created
         PlaceBossLevelItemsOnDungeon();
+        // Places the Player and the Boss on the map knowing its always a wandom walk map
+        PlacePlayerAndBossOnRandomWalkDungeon();
+    }
+
+    private void PlacePlayerAndBossOnRandomWalkDungeon()
+    {
+        // Sets the position of the main player inside the dungeon
+        // Lets pray (0,0) its always a good spot on this kind of maps
+        player.transform.position = Vector3.zero;
         // This method will place the final boss on the dungeon to challenge the main player on its quest
         PlaceFinalBossOnDungeon();
     }
@@ -126,10 +133,16 @@ public class GameManager : MonoBehaviour
         destroyAllSpawns();
         // Places the tiles on the tilemap to create the dungeon layout
         GenerateDungeonByName(RANDOM_WALK_ALGORITHM);
-        // Sets the position of the main player inside the dungeon
-        PlacePlayerOnDungeon();
         // Instantiates the items that will be available on the dungeon created
         PlaceBossLevelItemsOnDungeon();
+        PlaceMidLevelBossAndPlayerOnRandomWalk();
+    }
+
+    private void PlaceMidLevelBossAndPlayerOnRandomWalk()
+    {
+        // Sets the position of the main player inside the dungeon
+        // Lets pray (0,0) its always a good spot on this kind of maps
+        player.transform.position = Vector3.zero;
         // This method will place the mid level boss on the dungeon to challenge the main player on its quest
         PlaceMidLevelBossOnDungeon();
     }

--- a/First Try Roguelike/Assets/Scripts/Game Management/Spawner.cs
+++ b/First Try Roguelike/Assets/Scripts/Game Management/Spawner.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+
 public abstract class Spawner : MonoBehaviour
 {
     private List<GameObject> spawned = new List<GameObject>();
@@ -27,6 +28,18 @@ public abstract class Spawner : MonoBehaviour
         {
             spawnPrefabOnRandomPosition(dungeon, prefab);
         }
+    }
+
+    protected void spawnFinalBossOnDungeonByAmount(Dungeon dungeon, GameObject finalBossPrefab, int fINAL_BOSS_AMOUNT)
+    {
+        Vector3Int spawnPosition = dungeon.GetBossPosition();
+        addGameObjectToList(Instantiate(finalBossPrefab, spawnPosition, Quaternion.identity));
+    }
+
+    protected void spawnMidLevelBossOnDungeonByAmount(Dungeon dungeon, GameObject midLevelBossPrefab, int mIDLEVEL_BOSS_AMOUNT)
+    {
+        Vector3Int spawnPosition = dungeon.GetBossPosition();
+        addGameObjectToList(Instantiate(midLevelBossPrefab, spawnPosition, Quaternion.identity));
     }
 
     private void spawnPrefabOnRandomPosition(Dungeon dungeon, GameObject prefab)


### PR DESCRIPTION
* Player spawns always on (0,0) when spawning on boss levels
* Bosses may spawn on 6 different locations within camera space. The location depends on dungeon availability
* Doors now will always spawn entirely on the dungeon
* On non Boss levels, the player will spawn on a tile which radius is also built with floor tiles (The actual radius is set to 2 but can be tweaked)
* Larger numbers on radius may increase game loading times as it is harder to find a spot with more floor tiles surrounding it.
* Now also enemies and items follow this policy of spawning in free spaces which may lead to very crowded spaces and some pretty much empty **(PLEASE TRY THIS AND MAKE THE COMMENT IF NECCESARY TO CHANGE)**
* I believe this entirely fixes the player or bosses getting stuck on dead ends, **please test this also**